### PR TITLE
Added support for after_commit callbacks during soft delete

### DIFF
--- a/lib/delete_paranoid.rb
+++ b/lib/delete_paranoid.rb
@@ -24,11 +24,11 @@ module DeleteParanoid
         with_transaction_returning_status do
           _run_destroy_callbacks do
             update_attributes(:deleted_at => Time.now.utc)
+            @destroyed = true
           end
         end
       end
-
-      @destroyed = true
+      
       freeze
     end
   end


### PR DESCRIPTION
Moving the @destroyed = true into the callbacks block causes after_commit hooks to be called appropriately.
