### PR TITLE
Updated gemspec

### DIFF
--- a/delete_paranoid.gemspec
+++ b/delete_paranoid.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<mocha>, [">= 0"])
   s.add_development_dependency(%q<bundler>, [">= 0"])
   s.add_development_dependency(%q<sqlite3-ruby>, ["~> 1.3.2"])
-  s.add_development_dependency(%q<ruby-debug>, [">= 0"])
   s.add_development_dependency(%q<timecop>, [">= 0"])
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Hi,

I've made some commits that facilitates for using delete paranoid with recent installments of Ruby and Ruby on Rails.

Regards,
Johannes
