### PR TITLE
use _permanently instead of trailing-bang since rails4 uses #destroy!

### DIFF
--- a/lib/delete_paranoid.rb
+++ b/lib/delete_paranoid.rb
@@ -3,12 +3,12 @@ require 'active_record'
 
 module ActiveRecord
   class Relation
-    alias_method :delete_all!, :delete_all
+    alias_method :delete_all_permanently, :delete_all
     def delete_all(conditions = nil)
       if @klass.paranoid?
         update_all({:deleted_at => Time.now.utc}, conditions)
       else
-        delete_all!(conditions)
+        delete_all_permanently(conditions)
       end
     end
   end
@@ -17,7 +17,7 @@ end
 module DeleteParanoid
   module ActiveRecordExtensions
     def acts_as_paranoid
-      default_scope where(:deleted_at => nil)
+      default_scope { where(:deleted_at => nil) }
 
       extend DeleteParanoid::ClassMethods
       include DeleteParanoid::InstanceMethods
@@ -29,9 +29,9 @@ module DeleteParanoid
   end
 
   module ClassMethods
-    # permenantly delete the record from the database
-    def delete!(id_or_array)
-      where(self.primary_key => id_or_array).delete_all!
+    # permanently delete the record from the database
+    def delete_permanently(id_or_array)
+      where(self.primary_key => id_or_array).delete_all_permanently
     end
     # allow for queries within block to find soft deleted records
     def with_deleted
@@ -45,19 +45,19 @@ module DeleteParanoid
   end
 
   module InstanceMethods
-    # permenantly delete this specific instance from the database
-    def destroy!
+    # permanently delete this specific instance from the database
+    def destroy_permanently
       result = destroy
       self.class.with_deleted do
-        self.class.delete! self.id
+        self.class.delete_permanently self.id
       end
       result
     end
     # permenantly delete this specific instance from the database
-    def delete!
+    def delete_permanently
       result = delete
       self.class.with_deleted do
-        self.class.delete! self.id
+        self.class.delete_permanently self.id
       end
       result
     end

--- a/test/test_delete_paranoid.rb
+++ b/test/test_delete_paranoid.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'helper')
+require File.join(File.expand_path(File.dirname(__FILE__)), 'helper.rb')
 
 class TestDeleteParanoid < Test::Unit::TestCase
   context 'with non-paranoid activerecord class' do
@@ -22,7 +22,6 @@ class TestDeleteParanoid < Test::Unit::TestCase
         @blog.destroy
         @blog
       end
-      
       should destroy_subject.softly.and_freeze.and_mark_as_destroyed
       should trigger_callbacks_for :destroy
       should_not trigger_callbacks_for :update
@@ -34,32 +33,32 @@ class TestDeleteParanoid < Test::Unit::TestCase
       end
       should destroy_subject.softly
     end
-    context "when destroying instance with Class.delete_all!" do
+    context "when destroying instance with Class.delete_all_permanently" do
       subject do
-        Blog.where({:id => @blog.id}).delete_all!
+        Blog.where({:id => @blog.id}).delete_all_permanently
         @blog
       end
       should destroy_subject
     end
-    context "when destroying instance with Class.delete!" do
+    context "when destroying instance with Class.delete_permanently" do
       subject do
-        Blog.delete! @blog.id
+        Blog.delete_permanently @blog.id
         @blog
       end
       should destroy_subject
     end
-    context 'when destroying instance with instance.destroy!' do
+    context 'when destroying instance with instance.destroy_permanently' do
       subject do
-        @blog.destroy!
+        @blog.destroy_permanently
         @blog
       end
       should destroy_subject
       should trigger_callbacks_for :destroy
       should_not trigger_callbacks_for :update
     end
-    context 'when destroying instance with instance.delete!' do
+    context 'when destroying instance with instance.delete_permanently' do
       subject do
-        @blog.delete!
+        @blog.delete_permanently
         @blog
       end
       should destroy_subject
@@ -81,9 +80,9 @@ class TestDeleteParanoid < Test::Unit::TestCase
       should trigger_callbacks_for :destroy
       #should_not trigger_callbacks_for :update
     end
-    context 'when destroying parent paranoid instance with delete_all!' do
+    context 'when destroying parent paranoid instance with delete_all_permanently' do
        subject do
-         Blog.where({:id => @blog.id}).delete_all!
+         Blog.where({:id => @blog.id}).delete_all_permanently
          @comment
        end
 
@@ -106,9 +105,9 @@ class TestDeleteParanoid < Test::Unit::TestCase
       should trigger_callbacks_for :destroy
       #should_not trigger_callbacks_for :update
     end
-    context 'when destroying parent paranoid instance with delete_all!' do
+    context 'when destroying parent paranoid instance with delete_all_permanently' do
        subject do
-         Blog.where({:id => @blog.id}).delete_all!
+         Blog.where({:id => @blog.id}).delete_all_permanently
          @link
        end
 


### PR DESCRIPTION
Rails4 introduces a #destroy! method that raises in case of error, analogous to #create vs. #create! and friends:
http://edgeapi.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-destroy-21

This PR 
a) proposes adjusting the api of delete_paranoid in order to not collide with that, by changing the trailing-bang to a suffix of "_permanently".
b) fixes the default_scope deprecation warning about lambdaization under rails4.
